### PR TITLE
feat: support worktrees in bare repositories

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,8 @@
 mod session_cmd;
 
 use anyhow::{Context, Result};
-use clap::{Parser, Subcommand};
+use clap::parser::ValueSource;
+use clap::{CommandFactory, FromArgMatches, Parser, Subcommand};
 use dialoguer::Select;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -29,17 +30,125 @@ struct Cli {
     command: Commands,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) enum RepoLayout {
+    Normal {
+        root: PathBuf,
+    },
+    Bare {
+        git_dir: PathBuf,
+        has_worktree: bool,
+    },
+}
+
 struct RepoConfig {
-    root: PathBuf,
+    layout: RepoLayout,
     worktree_dir: PathBuf,
+    git_cwd: PathBuf,
 }
 
 impl RepoConfig {
-    fn new(dir: &Path) -> Result<Self> {
-        let root = get_repo_root()?;
-        let worktree_dir = root.join(dir);
-        Ok(Self { root, worktree_dir })
+    fn new(dir_arg: &Path, dir_explicit: bool) -> Result<Self> {
+        let layout = resolve_layout()?;
+        let (git_cwd, worktree_dir) = match &layout {
+            RepoLayout::Normal { root } => (root.clone(), root.join(dir_arg)),
+            RepoLayout::Bare { git_dir, .. } => {
+                let parent = git_dir
+                    .parent()
+                    .ok_or_else(|| anyhow::anyhow!("Bare git dir has no parent: {:?}", git_dir))?
+                    .to_path_buf();
+                let worktree_dir = if dir_explicit {
+                    if dir_arg.is_absolute() {
+                        dir_arg.to_path_buf()
+                    } else {
+                        parent.join(dir_arg)
+                    }
+                } else {
+                    parent
+                };
+                (git_dir.clone(), worktree_dir)
+            }
+        };
+        Ok(Self {
+            layout,
+            worktree_dir,
+            git_cwd,
+        })
     }
+
+    fn is_bare(&self) -> bool {
+        matches!(self.layout, RepoLayout::Bare { .. })
+    }
+
+    fn has_worktree(&self) -> bool {
+        match &self.layout {
+            RepoLayout::Normal { .. } => true,
+            RepoLayout::Bare { has_worktree, .. } => *has_worktree,
+        }
+    }
+
+    fn session_cwd(&self) -> &Path {
+        match &self.layout {
+            RepoLayout::Normal { root } => root,
+            RepoLayout::Bare { .. } => &self.worktree_dir,
+        }
+    }
+
+    fn status_cwd(&self) -> &Path {
+        match &self.layout {
+            RepoLayout::Normal { .. } => self.session_cwd(),
+            RepoLayout::Bare { .. } => &self.git_cwd,
+        }
+    }
+}
+
+fn resolve_layout() -> Result<RepoLayout> {
+    let is_bare = git_rev_parse(&["--is-bare-repository"])?;
+    let git_common_dir = git_rev_parse(&["--git-common-dir"])?;
+    let git_common_path = std::env::current_dir()?
+        .join(&git_common_dir)
+        .canonicalize()
+        .unwrap_or_else(|_| PathBuf::from(&git_common_dir));
+
+    if is_bare == "true" {
+        return Ok(RepoLayout::Bare {
+            git_dir: git_common_path,
+            has_worktree: false,
+        });
+    }
+
+    // Detect being inside a linked worktree of a bare repo: the common-dir's
+    // own `core.bare` is true.
+    let common_is_bare = Command::new("git")
+        .args(["config", "--bool", "core.bare"])
+        .current_dir(&git_common_path)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim() == "true")
+        .unwrap_or(false);
+
+    if common_is_bare {
+        return Ok(RepoLayout::Bare {
+            git_dir: git_common_path,
+            has_worktree: true,
+        });
+    }
+
+    let root = get_repo_root()?;
+    Ok(RepoLayout::Normal { root })
+}
+
+fn git_rev_parse(args: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .arg("rev-parse")
+        .args(args)
+        .output()
+        .context("Failed to execute git rev-parse")?;
+    if !output.status.success() {
+        anyhow::bail!("Not a git repository");
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
 #[derive(Subcommand)]
@@ -136,8 +245,13 @@ fn get_root_branch() -> String {
 }
 
 fn main() -> Result<()> {
-    let cli = Cli::parse();
-    let config = RepoConfig::new(&cli.dir)?;
+    let matches = Cli::command().get_matches();
+    let cli = Cli::from_arg_matches(&matches)?;
+    let dir_explicit = matches!(
+        matches.value_source("dir"),
+        Some(ValueSource::CommandLine) | Some(ValueSource::EnvVariable)
+    );
+    let config = RepoConfig::new(&cli.dir, dir_explicit)?;
 
     match cli.command {
         Commands::New {
@@ -148,31 +262,37 @@ fn main() -> Result<()> {
         Commands::Use { name } => cmd_use(&config, name),
         Commands::Ls => cmd_ls(&config),
         Commands::Rm { name } => cmd_rm(&config, name),
-        Commands::Which => cmd_which(&config.root),
+        Commands::Which => cmd_which(&std::env::current_dir()?),
         Commands::Session { mode, action } => run_session(&config, mode, action),
     }
 }
 
 fn cmd_new(config: &RepoConfig, name: Option<String>, base: &str, print_path: bool) -> Result<()> {
-    check_not_in_worktree(&config.root)?;
+    if !config.is_bare() {
+        check_not_in_worktree(&std::env::current_dir()?)?;
+    }
 
-    let current_branch = get_current_branch()?;
     let root_branch = get_root_branch();
 
     let name = match name {
         Some(n) => n,
         None => {
-            if current_branch == root_branch {
-                anyhow::bail!(
-                    "On root branch '{}'. Specify a name: wt new <name>",
-                    root_branch
-                );
+            if config.has_worktree() {
+                let current_branch = get_current_branch()?;
+                if current_branch == root_branch {
+                    anyhow::bail!(
+                        "On root branch '{}'. Specify a name: wt new <name>",
+                        root_branch
+                    );
+                }
+                current_branch
+            } else {
+                root_branch.clone()
             }
-            current_branch.clone()
         }
     };
 
-    let manager = WorktreeManager::new(config.root.clone())?;
+    let manager = WorktreeManager::new(config.git_cwd.clone())?;
 
     if let Some(info) = manager.get_worktree_info(&name)? {
         eprintln!(
@@ -188,16 +308,23 @@ fn cmd_new(config: &RepoConfig, name: Option<String>, base: &str, print_path: bo
         return Ok(());
     }
 
-    // If creating worktree for currently checked out branch, migrate the work
-    let migrating = name == current_branch && current_branch != root_branch;
-    let had_changes = if migrating {
-        migrate_from_current_branch(&config.root, &root_branch)?
-    } else {
+    // Migration only makes sense in Normal layout (there is a working tree to migrate from).
+    let had_changes = if config.is_bare() {
         false
+    } else {
+        let current_branch = get_current_branch()?;
+        let migrating = name == current_branch && current_branch != root_branch;
+        if migrating {
+            migrate_from_current_branch(&config.git_cwd, &root_branch)?
+        } else {
+            false
+        }
     };
 
-    ensure_worktrees_in_gitignore(&config.root, &config.worktree_dir)?;
-    std::fs::create_dir_all(&config.worktree_dir)?;
+    if !config.is_bare() {
+        ensure_worktrees_in_gitignore(&config.git_cwd, &config.worktree_dir)?;
+        std::fs::create_dir_all(&config.worktree_dir)?;
+    }
     let path = manager.create_worktree(&name, base, &config.worktree_dir, |remotes| {
         choose_remote_branch(&name, remotes)
     })?;
@@ -301,7 +428,7 @@ enum PickResult {
 }
 
 fn pick_worktree(config: &RepoConfig, prompt: &str) -> Result<PickResult> {
-    let manager = WorktreeManager::new(config.root.clone())?;
+    let manager = WorktreeManager::new(config.git_cwd.clone())?;
     let worktrees = manager.list_worktrees()?;
 
     let in_wt_shell = std::env::var("WT_ACTIVE").is_ok();
@@ -381,7 +508,7 @@ fn cmd_ls(config: &RepoConfig) -> Result<()> {
         }
         PickResult::Cancelled => {}
         PickResult::Selected(name) => {
-            let manager = WorktreeManager::new(config.root.clone())?;
+            let manager = WorktreeManager::new(config.git_cwd.clone())?;
             let wt_info = manager
                 .get_worktree_info(&name)?
                 .ok_or_else(|| anyhow::anyhow!("Worktree not found"))?;
@@ -404,7 +531,7 @@ fn cmd_rm(config: &RepoConfig, name: Option<String>) -> Result<()> {
         },
     };
 
-    let manager = WorktreeManager::new(config.root.clone())?;
+    let manager = WorktreeManager::new(config.git_cwd.clone())?;
     manager.remove_worktree(&name)?;
     eprintln!("Removed worktree: {}", name);
     Ok(())
@@ -417,13 +544,13 @@ fn cmd_which(repo_path: &Path) -> Result<()> {
 }
 
 fn cmd_use(config: &RepoConfig, name: Option<String>) -> Result<()> {
-    let manager = WorktreeManager::new(config.root.clone())?;
+    let manager = WorktreeManager::new(config.git_cwd.clone())?;
     let worktrees = manager.list_worktrees()?;
 
     let wt_name = match name {
         Some(n) => n,
         None => {
-            let current = get_current_worktree_name(&config.root)?;
+            let current = get_current_worktree_name(&std::env::current_dir()?)?;
             if current == "main" {
                 anyhow::bail!("Not in a worktree. Specify a worktree name: wt use <name>");
             }

--- a/src/session_cmd.rs
+++ b/src/session_cmd.rs
@@ -4,6 +4,8 @@ use dialoguer::Select;
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 
+#[cfg(test)]
+use crate::RepoLayout;
 use crate::{cmd_ls, RepoConfig};
 use wt::config::{Config, SessionMode};
 use wt::session::{retain_live_sessions, SessionState, WindowsSessionInfo};
@@ -65,7 +67,7 @@ struct SessionRmProbe {
 
 impl<'a> SessionCmdContext<'a> {
     fn new(repo: &'a RepoConfig, mode_override: Option<SessionMode>) -> Self {
-        let config = Config::load_for_repo(&repo.root);
+        let config = Config::load_for_repo(repo.session_cwd());
         let mode = mode_override.unwrap_or(config.session.mode);
 
         Self { repo, config, mode }
@@ -151,11 +153,15 @@ fn ensure_worktree_path(
     name: &str,
     base: &str,
 ) -> Result<PathBuf> {
-    check_not_in_worktree(&context.repo.root)?;
+    if !context.repo.is_bare() {
+        check_not_in_worktree(&std::env::current_dir()?)?;
+    }
 
-    let manager = WorktreeManager::new(context.repo.root.clone())?;
-    ensure_worktrees_in_gitignore(&context.repo.root, &context.repo.worktree_dir)?;
-    std::fs::create_dir_all(&context.repo.worktree_dir)?;
+    let manager = WorktreeManager::new(context.repo.git_cwd.clone())?;
+    if !context.repo.is_bare() {
+        ensure_worktrees_in_gitignore(&context.repo.git_cwd, &context.repo.worktree_dir)?;
+        std::fs::create_dir_all(&context.repo.worktree_dir)?;
+    }
 
     match manager.get_worktree_info(name)? {
         Some(info) => {
@@ -288,7 +294,7 @@ fn cmd_session_add_panes(
     if !tmux.session_exists()? {
         eprintln!("Creating tmux session: {}", SESSION_NAME);
         if watch {
-            create_status_window_session(&tmux, &context.repo.root)?;
+            create_status_window_session(&tmux, context.repo.status_cwd())?;
             tmux.create_window(name, &worktree_path)?;
         } else {
             tmux.create_session(name, &worktree_path)?;
@@ -296,7 +302,7 @@ fn cmd_session_add_panes(
         tmux.setup_worktree_layout(name, &worktree_path, panes, &session_config)?;
     } else {
         if watch {
-            ensure_status_window(&tmux, &context.repo.root)?;
+            ensure_status_window(&tmux, context.repo.status_cwd())?;
         }
 
         let windows = tmux.list_windows()?;
@@ -627,7 +633,7 @@ fn agent_window_status(tmux: &TmuxManager) -> AgentStatus {
 }
 
 fn probe_session_rm(context: &SessionCmdContext<'_>, name: &str) -> Result<SessionRmProbe> {
-    let manager = WorktreeManager::new(context.repo.root.clone())?;
+    let manager = WorktreeManager::new(context.repo.git_cwd.clone())?;
     let panes_tmux = TmuxManager::new(SESSION_NAME);
     let panes_has_worktree = if panes_tmux.session_exists()? {
         panes_tmux
@@ -793,7 +799,10 @@ mod tests {
 
         let context = SessionCmdContext {
             repo: &crate::RepoConfig {
-                root: std::path::PathBuf::from("/tmp/repo"),
+                layout: RepoLayout::Normal {
+                    root: std::path::PathBuf::from("/tmp/repo"),
+                },
+                git_cwd: std::path::PathBuf::from("/tmp/repo"),
                 worktree_dir: std::path::PathBuf::from("/tmp/repo/.worktrees"),
             },
             config,
@@ -815,7 +824,10 @@ mod tests {
         let original_agent_cmd = config.session.agent_cmd.clone();
         let context = SessionCmdContext {
             repo: &crate::RepoConfig {
-                root: std::path::PathBuf::from("/tmp/repo"),
+                layout: RepoLayout::Normal {
+                    root: std::path::PathBuf::from("/tmp/repo"),
+                },
+                git_cwd: std::path::PathBuf::from("/tmp/repo"),
                 worktree_dir: std::path::PathBuf::from("/tmp/repo/.worktrees"),
             },
             config,
@@ -835,7 +847,10 @@ mod tests {
 
         let context = SessionCmdContext {
             repo: &crate::RepoConfig {
-                root: std::path::PathBuf::from("/tmp/repo"),
+                layout: RepoLayout::Normal {
+                    root: std::path::PathBuf::from("/tmp/repo"),
+                },
+                git_cwd: std::path::PathBuf::from("/tmp/repo"),
                 worktree_dir: std::path::PathBuf::from("/tmp/repo/.worktrees"),
             },
             config,

--- a/src/worktree_manager.rs
+++ b/src/worktree_manager.rs
@@ -8,6 +8,54 @@ fn sanitize_for_path(name: &str) -> String {
     name.replace('/', "--")
 }
 
+struct ParsedWorktreeEntry {
+    path: PathBuf,
+    branch: Option<String>,
+}
+
+struct ParsingWorktree {
+    path: PathBuf,
+    branch: Option<String>,
+    bare: bool,
+}
+
+fn flush_worktree(current: &mut Option<ParsingWorktree>, entries: &mut Vec<ParsedWorktreeEntry>) {
+    if let Some(wt) = current.take() {
+        if !wt.bare {
+            entries.push(ParsedWorktreeEntry {
+                path: wt.path,
+                branch: wt.branch,
+            });
+        }
+    }
+}
+
+fn parse_worktree_porcelain(stdout: &str) -> Vec<ParsedWorktreeEntry> {
+    let mut entries = Vec::new();
+    let mut current: Option<ParsingWorktree> = None;
+
+    for line in stdout.lines() {
+        if let Some(rest) = line.strip_prefix("worktree ") {
+            flush_worktree(&mut current, &mut entries);
+            current = Some(ParsingWorktree {
+                path: PathBuf::from(rest),
+                branch: None,
+                bare: false,
+            });
+        } else if let Some(rest) = line.strip_prefix("branch ") {
+            if let Some(wt) = current.as_mut() {
+                wt.branch = Some(rest.trim_start_matches("refs/heads/").to_string());
+            }
+        } else if line.trim() == "bare" {
+            if let Some(wt) = current.as_mut() {
+                wt.bare = true;
+            }
+        }
+    }
+    flush_worktree(&mut current, &mut entries);
+    entries
+}
+
 fn unsanitize_from_path(name: &str) -> String {
     name.replace("--", "/")
 }
@@ -103,16 +151,28 @@ pub fn ensure_worktrees_in_gitignore(repo_path: &Path, worktree_dir: &Path) -> R
 }
 
 pub fn check_not_in_worktree(path: &Path) -> Result<()> {
-    let mut current = path;
-    while let Some(parent) = current.parent() {
-        if current
-            .file_name()
-            .map(|n| n == ".worktrees")
-            .unwrap_or(false)
-        {
-            anyhow::bail!("Cannot create nested worktrees: already inside a .worktrees directory");
-        }
-        current = parent;
+    let output = Command::new("git")
+        .args(["rev-parse", "--git-dir"])
+        .current_dir(path)
+        .output();
+
+    let Ok(output) = output else {
+        return Ok(());
+    };
+    if !output.status.success() {
+        return Ok(());
+    }
+
+    let git_dir = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    // A linked worktree's --git-dir always ends with /worktrees/<name>.
+    // Using a suffix check avoids false positives from user paths that
+    // happen to contain "/worktrees/" as a non-git directory component.
+    let is_linked = git_dir
+        .rsplit_once("/worktrees/")
+        .map(|(_, name)| !name.is_empty() && !name.contains('/'))
+        .unwrap_or(false);
+    if is_linked {
+        anyhow::bail!("Cannot create nested worktrees: already inside a linked worktree");
     }
     Ok(())
 }
@@ -130,12 +190,13 @@ pub fn get_current_worktree_name(path: &Path) -> Result<String> {
 
     let git_dir = String::from_utf8_lossy(&output.stdout).trim().to_string();
 
-    if let Some(pos) = git_dir.find("/.git/worktrees/") {
-        let worktree_name = &git_dir[pos + "/.git/worktrees/".len()..];
-        Ok(worktree_name.to_string())
-    } else {
-        Ok("main".to_string())
+    // A linked worktree's --git-dir is always <common-dir>/worktrees/<name>.
+    if let Some((_, name)) = git_dir.rsplit_once("/worktrees/") {
+        if !name.is_empty() && !name.contains('/') {
+            return Ok(name.to_string());
+        }
     }
+    Ok("main".to_string())
 }
 
 #[derive(Debug, Clone)]
@@ -151,7 +212,12 @@ pub struct WorktreeManager {
 
 impl WorktreeManager {
     pub fn new(repo_path: PathBuf) -> Result<Self> {
-        if !repo_path.join(".git").exists() {
+        let output = Command::new("git")
+            .args(["rev-parse", "--git-common-dir"])
+            .current_dir(&repo_path)
+            .output()
+            .context("Failed to execute git rev-parse")?;
+        if !output.status.success() {
             anyhow::bail!("Not a git repository: {:?}", repo_path);
         }
         Ok(Self { repo_path })
@@ -340,33 +406,12 @@ impl WorktreeManager {
             );
         }
 
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let mut worktrees = Vec::new();
-        let mut current_worktree: Option<(PathBuf, Option<String>)> = None;
-
-        for line in stdout.lines() {
-            if line.starts_with("worktree ") {
-                if let Some((path, branch)) = current_worktree.take() {
-                    worktrees.push(self.parse_worktree_entry(path, branch));
-                }
-                let path = PathBuf::from(line.strip_prefix("worktree ").unwrap());
-                current_worktree = Some((path, None));
-            } else if line.starts_with("branch ") {
-                if let Some((ref _path, ref mut branch)) = current_worktree {
-                    let branch_name = line
-                        .strip_prefix("branch ")
-                        .unwrap()
-                        .trim_start_matches("refs/heads/");
-                    *branch = Some(branch_name.to_string());
-                }
-            }
-        }
-
-        if let Some((path, branch)) = current_worktree {
-            worktrees.push(self.parse_worktree_entry(path, branch));
-        }
-
-        Ok(worktrees)
+        Ok(
+            parse_worktree_porcelain(&String::from_utf8_lossy(&output.stdout))
+                .into_iter()
+                .map(|entry| self.parse_worktree_entry(entry.path, entry.branch))
+                .collect(),
+        )
     }
 
     fn parse_worktree_entry(&self, path: PathBuf, branch: Option<String>) -> WorktreeInfo {
@@ -807,5 +852,41 @@ mod tests {
         // Remove should work with original name
         manager.remove_worktree("feature/auth").unwrap();
         assert!(!worktree_path.exists());
+    }
+
+    #[test]
+    fn test_parse_porcelain_drops_bare_entries() {
+        let porcelain = "\
+worktree /home/user/projects/todolist
+bare
+
+worktree /home/user/projects/todolist/feat
+HEAD abc123
+branch refs/heads/feat
+";
+        let entries = parse_worktree_porcelain(porcelain);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            entries[0].path,
+            PathBuf::from("/home/user/projects/todolist/feat")
+        );
+        assert_eq!(entries[0].branch.as_deref(), Some("feat"));
+    }
+
+    #[test]
+    fn test_parse_porcelain_normal_repo() {
+        let porcelain = "\
+worktree /home/user/projects/todolist
+HEAD abc123
+branch refs/heads/main
+
+worktree /home/user/projects/todolist/.worktrees/feat
+HEAD def456
+branch refs/heads/feat
+";
+        let entries = parse_worktree_porcelain(porcelain);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].branch.as_deref(), Some("main"));
+        assert_eq!(entries[1].branch.as_deref(), Some("feat"));
     }
 }

--- a/tests/bare_repo_test.rs
+++ b/tests/bare_repo_test.rs
@@ -1,0 +1,162 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+use wt::worktree_manager::{check_not_in_worktree, get_current_worktree_name, WorktreeManager};
+
+/// Set up a bare repo at `<parent>/.git` with a `main` branch holding one
+/// commit. Returns the `TempDir` (which is the parent dir) and the path
+/// to the bare git dir.
+fn setup_bare_repo() -> (TempDir, PathBuf) {
+    let parent = TempDir::new().unwrap();
+    let bare_dir = parent.path().join(".git");
+
+    Command::new("git")
+        .args(["init", "--bare", "-b", "main"])
+        .arg(&bare_dir)
+        .output()
+        .unwrap();
+
+    // Configure identity for commits via plumbing.
+    Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&bare_dir)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&bare_dir)
+        .output()
+        .unwrap();
+
+    // Build an initial commit via plumbing (no working tree available).
+    let empty_tree_sha = run_git_capture(
+        &bare_dir,
+        &["mktree"],
+        "", // empty stdin → empty tree
+    );
+    let commit_sha = run_git_capture(
+        &bare_dir,
+        &["commit-tree", &empty_tree_sha, "-m", "initial"],
+        "",
+    );
+
+    let status = Command::new("git")
+        .args(["update-ref", "refs/heads/main", &commit_sha])
+        .current_dir(&bare_dir)
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    (parent, bare_dir)
+}
+
+fn run_git_capture(cwd: &Path, args: &[&str], stdin: &str) -> String {
+    use std::io::Write;
+    let mut child = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(stdin.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    assert!(
+        out.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+#[test]
+fn test_worktree_manager_new_succeeds_on_bare() {
+    let (_parent, bare) = setup_bare_repo();
+    let manager = WorktreeManager::new(bare.clone());
+    assert!(
+        manager.is_ok(),
+        "WorktreeManager::new on bare should succeed"
+    );
+}
+
+#[test]
+fn test_create_and_list_worktree_on_bare() {
+    let (parent, bare) = setup_bare_repo();
+    let manager = WorktreeManager::new(bare.clone()).unwrap();
+
+    let path = manager
+        .create_worktree("feat", "main", parent.path(), |_| unreachable!())
+        .unwrap();
+
+    assert_eq!(path, parent.path().join("feat"));
+    assert!(path.exists());
+
+    let worktrees = manager.list_worktrees().unwrap();
+    let names: Vec<_> = worktrees
+        .iter()
+        .map(|w| w.task_id.clone())
+        .filter(|n| !n.is_empty())
+        .collect();
+    assert_eq!(names, vec!["feat"]);
+}
+
+#[test]
+fn test_get_current_worktree_name_on_linked_bare() {
+    let (parent, bare) = setup_bare_repo();
+    let manager = WorktreeManager::new(bare.clone()).unwrap();
+
+    let path = manager
+        .create_worktree("feat", "main", parent.path(), |_| unreachable!())
+        .unwrap();
+
+    let name = get_current_worktree_name(&path).unwrap();
+    assert_eq!(name, "feat");
+}
+
+#[test]
+fn test_check_not_in_worktree_for_bare() {
+    let (parent, bare) = setup_bare_repo();
+    let manager = WorktreeManager::new(bare.clone()).unwrap();
+
+    let linked = manager
+        .create_worktree("feat", "main", parent.path(), |_| unreachable!())
+        .unwrap();
+
+    assert!(check_not_in_worktree(&linked).is_err());
+    assert!(check_not_in_worktree(&bare).is_ok());
+    assert!(check_not_in_worktree(parent.path()).is_ok());
+}
+
+#[test]
+fn test_remove_worktree_on_bare() {
+    let (parent, bare) = setup_bare_repo();
+    let manager = WorktreeManager::new(bare.clone()).unwrap();
+
+    let path = manager
+        .create_worktree("feat", "main", parent.path(), |_| unreachable!())
+        .unwrap();
+    assert!(path.exists());
+
+    manager.remove_worktree("feat").unwrap();
+    assert!(!path.exists());
+}
+
+#[test]
+fn test_no_gitignore_or_worktrees_dir_created_for_bare() {
+    let (parent, bare) = setup_bare_repo();
+    let manager = WorktreeManager::new(bare.clone()).unwrap();
+
+    manager
+        .create_worktree("feat", "main", parent.path(), |_| unreachable!())
+        .unwrap();
+
+    assert!(!parent.path().join(".worktrees").exists());
+    assert!(!parent.path().join(".gitignore").exists());
+}

--- a/tests/which_test.rs
+++ b/tests/which_test.rs
@@ -51,6 +51,67 @@ fn test_which_returns_main_in_main_repo() {
 }
 
 #[test]
+fn test_which_returns_main_when_git_dir_contains_worktrees_segment() {
+    use wt::worktree_manager::get_current_worktree_name;
+
+    let temp_root = TempDir::new().unwrap();
+    let repo_path = temp_root
+        .path()
+        .join("nested")
+        .join("worktrees")
+        .join("repo-with-worktrees-segment");
+    fs::create_dir_all(&repo_path).unwrap();
+
+    let output = Command::new("git")
+        .args(["init", "-b", "main"])
+        .current_dir(&repo_path)
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "failed to init repo: {:?}", output);
+
+    let output = Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo_path)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "failed to set user.email: {:?}",
+        output
+    );
+
+    let output = Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo_path)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "failed to set user.name: {:?}",
+        output
+    );
+
+    fs::write(repo_path.join("README.md"), "# Test Repo\n").unwrap();
+
+    let output = Command::new("git")
+        .args(["add", "."])
+        .current_dir(&repo_path)
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "failed to add file: {:?}", output);
+
+    let output = Command::new("git")
+        .args(["commit", "-m", "Initial commit"])
+        .current_dir(&repo_path)
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "failed to commit: {:?}", output);
+
+    let result = get_current_worktree_name(&repo_path).unwrap();
+    assert_eq!(result, "main");
+}
+
+#[test]
 fn test_which_returns_worktree_name_in_worktree() {
     use wt::worktree_manager::get_current_worktree_name;
 
@@ -162,14 +223,22 @@ fn test_check_not_in_worktree_allows_normal_path() {
 }
 
 #[test]
-fn test_check_not_in_worktree_rejects_worktrees_dir() {
+fn test_check_not_in_worktree_rejects_linked_worktree() {
     use wt::worktree_manager::check_not_in_worktree;
 
-    let temp_dir = TempDir::new().unwrap();
-    let worktrees_path = temp_dir.path().join(".worktrees").join("some-worktree");
-    fs::create_dir_all(&worktrees_path).unwrap();
+    let repo = setup_git_repo();
+    let worktree_dir = TempDir::new().unwrap();
+    let worktree_path = worktree_dir.path().join("feature-xyz");
 
-    let result = check_not_in_worktree(&worktrees_path);
+    Command::new("git")
+        .args(["worktree", "add", "-b", "feature-xyz"])
+        .arg(&worktree_path)
+        .arg("main")
+        .current_dir(repo.path())
+        .output()
+        .unwrap();
+
+    let result = check_not_in_worktree(&worktree_path);
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("nested"));
 }


### PR DESCRIPTION
This adds support for worktrees in bare repositories and hardens linked-worktree detection logic to avoid false positives for non-worktree paths.

It also adds regression coverage for worktree name parsing when a repository path includes a 'worktrees' segment in its filesystem location.

Closes #24
